### PR TITLE
Added optional POST callback

### DIFF
--- a/line-notify-sdk.js
+++ b/line-notify-sdk.js
@@ -14,7 +14,7 @@ class LINE_Notify_SDK {
             return true
     }
 
-    set_Oauth_URL(response_type, scope, state) {
+    set_Oauth_URL(response_type, scope, state,form_post=null) {
         
         this.check_args_is_set()
         
@@ -25,7 +25,8 @@ class LINE_Notify_SDK {
 	        '&redirect_uri=' + this.redirect_uri +
 	        '&scope=' + scope +
 	        '&state=' + state
-	        return Oauth_URL
+	    if (form_post) Oauth_URL += '&response_mode=form_post'
+		return Oauth_URL
         }
 
         return get_Oauth_URL


### PR DESCRIPTION
- Added an optional paramater for `get_Oauth_URL` generator  function, to allow `response_mode=form_post` as an optional query parameter
- This allows LINE Notify server to directly send POST request to callback URL instead of URL redirection
- This prevents WSRF Token attacks

From API docs:	

> By assigning "form_post", sends POST request to redirect_uri by form post instead of redirecting
> Extended specifications: https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html
> 
> We recommend assigning this to prevent code parameter leaks in certain environments